### PR TITLE
ASoC: ops: Shift tested values in snd_soc_put_volsw_sx() by +min

### DIFF
--- a/sound/soc/soc-ops.c
+++ b/sound/soc/soc-ops.c
@@ -449,7 +449,7 @@ int snd_soc_put_volsw_sx(struct snd_kcontrol *kcontrol,
 	unsigned int val, val_mask, val2 = 0;
 
 	val = ucontrol->value.integer.value[0];
-	if (mc->platform_max && val > mc->platform_max)
+	if (mc->platform_max && ((int)val + min) > mc->platform_max)
 		return -EINVAL;
 	if (val > max - min)
 		return -EINVAL;


### PR DESCRIPTION
Followup to e41846dbe6f49d305c1a8fc229c5deabd66e3e24:
"ASoC: ops: Shift tested values in snd_soc_put_volsw() by +min"
Adding the same change to snd_soc_put_volsw_sx

Seen also at https://github.com/baunilla/android_kernel_xiaomi_rosy/commit/969b9d366c1e9564e173aea325ec544dcd7804ff

Fixes the "hear your own voice"-issue during headset calls which may lead to feedback loops and hissing.

@bananafunction Just for visibility